### PR TITLE
Changes to make demo work with current browser versions.

### DIFF
--- a/sdp.txt
+++ b/sdp.txt
@@ -2,26 +2,25 @@
 Firefox offer
 ============================================================
 
-RTCSessionDescription { type: "offer", sdp: "v=0\r\no=mozilla...THIS_IS_SDPARTA-62.0 305778100508406010 0 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\na=sendrecv\r\na=fingerprint:sha-256 BA:B2:2E:A4:76:BA:C4:A2:8A:1F:65:40:46:E0:8F:D0:71:45:2B:5B:66:D6:FE:92:C8:F5:52:FA:E2:7B:75:26\r\na=group:BUNDLE sdparta_0\r\na=ice-options:trickle\r\na=msid-semantic:WMS *\r\nm=application 9 DTLS/SCTP 5000\r\nc=IN IP4 0.0.0.0\r\na=sendrecv\r\na=ice-pwd:0c983e9d4b327c3e03b2307929f05437\r\na=ice-ufrag:1db47d87\r\na=mid:sdparta_0\r\na=sctpmap:5000 webrtc-datachannel 256\r\na=setup:actpass\r\na=max-message-size:1073741823\r\n" }
+RTCSessionDescription { type: "offer", sdp: "v=0\r\no=mozilla...THIS_IS_SDPARTA-76.0.1 6398396600349405389 0 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\na=sendrecv\r\na=fingerprint:sha-256 CD:1B:8B:E7:FE:06:A5:21:98:43:48:B0:82:04:55:56:59:BC:9E:F4:EB:7A:EF:FB:32:CA:AF:EC:C5:A0:0E:C9\r\na=group:BUNDLE 0\r\na=ice-options:trickle\r\na=msid-semantic:WMS *\r\nm=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\nc=IN IP4 0.0.0.0\r\na=sendrecv\r\na=ice-pwd:e154da96f6e063cb6319062c340ba290\r\na=ice-ufrag:a856c19d\r\na=mid:0\r\na=setup:actpass\r\na=sctp-port:5000\r\na=max-message-size:1073741823\r\n" }
 
 v=0
-o=mozilla...THIS_IS_SDPARTA-62.0 305778100508406010 0 IN IP4 0.0.0.0
+o=mozilla...THIS_IS_SDPARTA-76.0.1 6398396600349405389 0 IN IP4 0.0.0.0
 s=-
 t=0 0
 a=sendrecv
-a=fingerprint:sha-256 BA:B2:2E:A4:76:BA:C4:A2:8A:1F:65:40:46:E0:8F:D0:71:45:2B:5B:66:D6:FE:92:C8:F5:52:FA:E2:7B:75:26
-a=group:BUNDLE sdparta_0
+a=fingerprint:sha-256 CD:1B:8B:E7:FE:06:A5:21:98:43:48:B0:82:04:55:56:59:BC:9E:F4:EB:7A:EF:FB:32:CA:AF:EC:C5:A0:0E:C9
+a=group:BUNDLE 0
 a=ice-options:trickle
 a=msid-semantic:WMS *
-
-m=application 9 DTLS/SCTP 5000
+m=application 9 UDP/DTLS/SCTP webrtc-datachannel
 c=IN IP4 0.0.0.0
 a=sendrecv
-a=ice-pwd:0c983e9d4b327c3e03b2307929f05437
-a=ice-ufrag:1db47d87
-a=mid:sdparta_0
-a=sctpmap:5000 webrtc-datachannel 256
+a=ice-pwd:e154da96f6e063cb6319062c340ba290
+a=ice-ufrag:a856c19d
+a=mid:0
 a=setup:actpass
+a=sctp-port:5000
 a=max-message-size:1073741823
 
 
@@ -29,62 +28,61 @@ Chrome answer
 ============================================================
 
 v=0
-o=- 1561367523461712467 2 IN IP4 127.0.0.1
+o=- 8909699757337142222 2 IN IP4 127.0.0.1
 s=-
 t=0 0
-a=group:BUNDLE sdparta_0
+a=group:BUNDLE 0
 a=msid-semantic: WMS
-
-m=application 9 DTLS/SCTP 5000
+m=application 9 UDP/DTLS/SCTP webrtc-datachannel
 c=IN IP4 0.0.0.0
 b=AS:30
-a=ice-ufrag:b/DP
-a=ice-pwd:5AT/bCtclVcE1UDc8I3p/0w2
+a=ice-ufrag:z5AD
+a=ice-pwd:dfB5wKT5CGc+zm1j+D0jZVb3
 a=ice-options:trickle
-a=fingerprint:sha-256 F8:41:CE:45:14:A3:00:91:88:69:F1:5B:32:83:75:C5:C0:B2:79:12:93:CA:8E:8C:89:5B:79:C1:91:68:E3:7B
+a=fingerprint:sha-256 70:72:95:DD:15:AA:63:27:A2:99:B5:81:07:D2:28:60:A2:3A:B6:F7:BB:9A:0F:07:A5:2E:10:93:CB:98:7D:54
 a=setup:active
-a=mid:sdparta_0
-a=sctpmap:5000 webrtc-datachannel 1024
+a=mid:0
+a=sctp-port:5000
+a=max-message-size:262144
 
 Chrome offer
 ============================================================
 
 v=0
-o=- 3517670525970367566 2 IN IP4 127.0.0.1
+o=- 5376996625809703872 2 IN IP4 127.0.0.1
 s=-
 t=0 0
-a=group:BUNDLE data
+a=group:BUNDLE 0
 a=msid-semantic: WMS
-
-m=application 9 DTLS/SCTP 5000
+m=application 9 UDP/DTLS/SCTP webrtc-datachannel
 c=IN IP4 0.0.0.0
-a=ice-ufrag:O2y3
-a=ice-pwd:5BqpwH1HUcN4ijl4WREsqh66
+a=ice-ufrag:J+zR
+a=ice-pwd:dn4388vIdAQu44hsIHq9UaQx
 a=ice-options:trickle
-a=fingerprint:sha-256 E7:9F:CF:EE:4B:FE:19:58:BF:98:8E:2C:E0:ED:65:30:4F:64:54:A4:EC:20:FD:99:96:B0:D1:7C:3A:9C:77:AB
+a=fingerprint:sha-256 C4:72:C0:09:EA:45:F3:EB:7D:F0:F1:42:4B:EB:6A:89:FC:25:62:C1:27:0B:EE:84:62:5E:B8:80:D1:92:E9:F0
 a=setup:actpass
-a=mid:data
-a=sctpmap:5000 webrtc-datachannel 1024
+a=mid:0
+a=sctp-port:5000
+a=max-message-size:262144
 
 Firefox answer
 ============================================================
 
 v=0
-o=mozilla...THIS_IS_SDPARTA-62.0 3624786973825708002 0 IN IP4 0.0.0.0
+o=mozilla...THIS_IS_SDPARTA-76.0.1 2613797844670679192 0 IN IP4 0.0.0.0
 s=-
 t=0 0
-a=fingerprint:sha-256 00:CF:41:76:CF:6B:81:9D:72:BD:1D:3B:1C:5E:C4:C4:42:A9:8D:6A:A6:90:46:0E:C1:FE:B2:AF:08:2D:B6:7A
-a=group:BUNDLE data
+a=fingerprint:sha-256 24:8C:7F:68:2D:78:EC:C7:61:3C:2D:7A:9E:EA:ED:57:1D:2F:69:57:1E:D8:7B:07:EC:0D:2C:36:14:BF:43:6B
+a=group:BUNDLE 0
 a=ice-options:trickle
 a=msid-semantic:WMS *
-
-m=application 9 DTLS/SCTP 5000
+m=application 9 UDP/DTLS/SCTP webrtc-datachannel
 c=IN IP4 0.0.0.0
 a=sendrecv
-a=ice-pwd:2e6983d1b756124bff54d798f64d4f0f
-a=ice-ufrag:61b63881
-a=mid:data
-a=sctpmap:5000 webrtc-datachannel 256
+a=ice-pwd:9346b22cd2a4992135b197c7aef80a38
+a=ice-ufrag:17d3553b
+a=mid:0
 a=setup:active
+a=sctp-port:5000
 a=max-message-size:1073741823
 


### PR DESCRIPTION
1. First change updates parsing of SDP offer and generation of answer because Chromium and Firefox switched to new format.

2. Currently browsers send special domain name instead of IP address for local ICE candidates. This can be bypassed by requesting getUserMedia or turned off in browser settings but because it is data only application and for now works only locally I instead put workaround in parser.